### PR TITLE
Update JobDriver_ScroungeFood.cs to simplify redundant tickAction toil

### DIFF
--- a/Source/Source/JobDriver_ScroungeFood.cs
+++ b/Source/Source/JobDriver_ScroungeFood.cs
@@ -17,10 +17,10 @@ namespace Hospitality
             this.FailOnDespawnedOrNull(TargetIndex.A);
             this.FailOnAggroMentalState(TargetIndex.A);
             this.FailOnIncapable(PawnCapacityDefOf.Manipulation);
-            Toil toil = GotoPawn(TargetIndex.A);
+            Toil toil = Toils_Goto.Goto(TargetIndex.A, PathEndMode.Touch);
             toil.socialMode = RandomSocialMode.Off;
             yield return toil;
-            Toil finalGoto = GotoPawn(TargetIndex.A);
+            Toil finalGoto = Toils_Goto.Goto(TargetIndex.A, PathEndMode.Touch);
             yield return Toils_Jump.JumpIf(finalGoto, () => !OtherPawn.Awake());
             Toil toil2 = Toils_Interpersonal.WaitToBeAbleToInteract(pawn);
             toil2.socialMode = RandomSocialMode.Off;
@@ -34,29 +34,7 @@ namespace Hospitality
             yield return ItemUtility.TakeToInventory(TargetIndex.B);
 
         }
-
-        public static Toil GotoPawn(TargetIndex targetInd)
-        {
-            var toil = ToilMaker.MakeToil();
-            toil.tickAction = delegate
-            {
-                var actor = toil.actor;
-                var target = actor.jobs.curJob.GetTarget(targetInd);
-
-                if (target != actor.pather.Destination || (!actor.pather.Moving && !actor.CanReachImmediate(target, PathEndMode.Touch)))
-                {
-                    actor.pather.StartPath(target, PathEndMode.Touch);
-                }
-                else if (actor.CanReachImmediate(target, PathEndMode.Touch))
-                {
-                    actor.jobs.curDriver.ReadyForNextToil();
-                }
-            };
-            toil.socialMode = RandomSocialMode.Off;
-            toil.defaultCompleteMode = ToilCompleteMode.Never;
-            return toil;
-        }
-
+        
         public static Toil AskForFood(TargetIndex targetInd, TargetIndex foodInd)
         {
             var toil = ToilMaker.MakeToil("Scrounge food interaction"); ;


### PR DESCRIPTION
Changed custom `GotoPawn` toil to `Toils_Goto.Goto` to remove redundant per-tick `CanReachImmediate` calls and conditional per-tick `StartPath` calls.

## Before
The original job (5631f7444e9798b162a3b7552df69b64b9fd38fb) used `Toils_Interpersonal.GotoInteractablePosition` (which puts the pawn within 3 cells of the target), but it was later updated to bring them closer using a custom toil with a `tickAction` loop that attempts to call `StartPath` every tick while under certain conditions (typically only once, but sometimes multiple ticks), and also calls `pawn.CanReachImmediate` every tick, sometimes twice (7b8d2a18eac0ab999661a2df449d4c46644b44a7).

## After
I recommend changing it from the custom `GotoPawn` to `Toils_Goto.Goto` with `PathEndMode.Touch`, since that already puts the pawn as close to the target as possible (without actually trying to occupy the cell). Unless there is something in Multiplayer (which I'm not familiar with), I can't see any reason to attempt to `StartPath` repeatedly every tick; either the path is valid on the first call, or it's not and should fail the job and try again later. Same with `CanReachImmediate` which the `pawn.pather.PatherTick` loop calls every tick anyways ¯\\\_(ツ)\_/¯

I've tested these changes in my own modded save and it seems to work, but you might be aware of some gotchas that I'm not.